### PR TITLE
Co-located events: TyDe 2016

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,4 @@ Supermonads
 J. Bracker, H. Nilsson.  
 
 Types for a Relational Algebra Library (Experience Report)  
-M. Agren, L. Augustsson. 
-
->>>>>>> upstream/master
+M. Agren, L. Augustsson.  

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Programming with Monadic CSP-Style Processes in Dependent Type Theory
 Bashar Igried and Anton Setzer.  
 
 Liberating Effects with Rows and Handlers  
-Daniel Hillerström and Sam Lindley.
+Daniel Hillerström and Sam Lindley.  
 ([draft](http://homepages.inf.ed.ac.uk/slindley/papers/links-effect-draft-june2016.pdf))  
 
 Parameterized Extensible Effects and Session Types (Extended Abstract)  

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ The Key Monad:Type-Safe Unconstrained Dynamic Typing
 P. Buiras, K. Claessen, A. Ploeg.  
 
 Lazy Graph Processing in Haskell  
-P. Dexter, Y. Liu, K. Chiu.
+P. Dexter, Y. Liu, K. Chiu.  
 ([draft](http://cs.binghamton.edu/~pdexter1/icfp-haskell2016-paper22.pdf))
 
 Non-recursive Make Considered Harmful  

--- a/README.md
+++ b/README.md
@@ -168,3 +168,9 @@ Jesper Cockx, Dominique Devriese, Frank Piessens
 As of writing, the submission process for ICFP'16 co-located events is
 not finished. Feel free to send a pull-request with list of accepted
 papers and contribute links to preprints.
+
+### TyDe 2016
+
+Liberating Effects with Rows and Handlers  
+Daniel Hillerström, Sam Lindley  
+([draft](http://homepages.inf.ed.ac.uk/slindley/papers/links-effect-draft-june2016.pdf))  


### PR DESCRIPTION
Added TyDe 2016 under co-located events, and I added my paper "Liberating Effects with Rows and Handlers" to the enumeration.
